### PR TITLE
Set PPMac address via environment variable PPMAC_HOST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.egg-info
 build/
 dist/
+
+.idea
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,13 @@
+======
+hxnfly
+======
+
+Specify PPMac host name or address by setting an environment variable PPMAC_HOST.
+
+Shell script::
+
+  export PPMAC_HOST="..."
+
+Python script::
+
+  os.environ["PPMAC_HOST"] = "..."

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Specify PPMac host name or address by setting an environment variable PPMAC_HOST
 
 Shell script::
 
-  export PPMAC_HOST="..."
+  export PPMAC_HOST=<host-name-or-ip>
 
 Python script::
 
-  os.environ["PPMAC_HOST"] = "..."
+  os.environ["PPMAC_HOST"] = "<host-name-or-ip>"

--- a/hxnfly/ppmac_util.py
+++ b/hxnfly/ppmac_util.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import logging
 
+import os
 import numpy as np
 import IPython
 from ppmac.pp_comm import PPComm

--- a/hxnfly/ppmac_util.py
+++ b/hxnfly/ppmac_util.py
@@ -10,13 +10,20 @@ logger = logging.getLogger(__name__)
 
 
 def ppmac_connect(force=False):
-    # Store the ppmac connection in the user namespace
+    """
+    Store the ppmac connection in the user namespace.
+    Set environment variable ``PPMAC_HOST`` to valid host name or IP address.
+    """
     ip = IPython.get_ipython()
     ppmac = None
     if force or '_ppmac' not in ip.user_ns:
         logger.debug('Connecting to the Power PMAC...')
         try:
-            ppmac = ip.user_ns['_ppmac'] = PPComm(host='10.3.2.115',
+            host = os.environ.get('PPMAC_HOST', None)
+            if not host:
+                raise ValueError("Host name is not set: environment variable 'PPMAC_HOST' is not set")
+
+            ppmac = ip.user_ns['_ppmac'] = PPComm(host=host,
                                                   fast_gather=True)
         except Exception as ex:
             logger.error('Failed to connect to Power PMAC: %s', ex,


### PR DESCRIPTION
Implemented the option of setting PPMac host name/address via environment variable PPMAC_HOST. Replaces hard coded IP address.