### PR TITLE
Fix import of xspress3 to be from `nslsii`

### DIFF
--- a/hxnfly/fly.py
+++ b/hxnfly/fly.py
@@ -19,7 +19,7 @@ from ophyd.status import Status
 from ophyd.device import Staged
 from ophyd.areadetector import FilePlugin
 
-from hxntools.detectors import Xspress3Detector
+from nslsii.detectors.xspress3 import Xspress3Detector
 from hxntools.shutter import (shutter_open, shutter_close)
 
 from . import SCRIPT_PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 bluesky
 databroker
-ophyd
 IPython
 nslsii
 numpy
+ophyd
 pandas
 pyepics
 scipy


### PR DESCRIPTION
There are failures in the CI, that have the wrong import of `Xspress3Detector` from hxntools that does not exist there anymore. This PR fixes the issue.