### PR TITLE
Live plotting issues

### DIFF
--- a/hxnfly/callbacks/liveimage.py
+++ b/hxnfly/callbacks/liveimage.py
@@ -3,15 +3,15 @@ import logging
 from collections import OrderedDict
 
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from .flydata import (catch_exceptions, SubscanDataHandler)
 from .liveplot import LivePlotBase
 from .roiplot import FlyRoiPlot
 
-
-loop = asyncio.get_event_loop()
 logger = logging.getLogger(__name__)
+mpl.rcParams['figure.raise_window'] = False
 
 
 def _sum_func(*values):
@@ -238,4 +238,3 @@ class FlyLiveImage(FlyRoiPlot):
                       **self.plot_kwargs)
             self.draw(fig)
             fig.canvas.manager.set_window_title(f"Final image - scan {self.scan_id}")
-

--- a/hxnfly/callbacks/liveplot.py
+++ b/hxnfly/callbacks/liveplot.py
@@ -5,14 +5,15 @@ from collections import OrderedDict
 import PyQt5
 import IPython
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from .flydata import (FlyDataCallbacks, catch_exceptions, SignalDataHandler)
 
 from matplotlib.backends.qt_compat import QtCore
 
-# loop = asyncio.get_event_loop()
 logger = logging.getLogger(__name__)
+mpl.rcParams['figure.raise_window'] = False
 
 
 def get_insertFig():


### PR DESCRIPTION
The PR addresses issues that were discovered while running experiments using code from https://github.com/NSLS-II-HXN/hxnfly/pull/9:

- Large scans that consist of multiple subscans are plotted incorrectly. Plotting for each subscan is started from the top of the image and already collected data is not displayed. The data should be appended to the data collected during previous subscans.

- Matplotlib figure window become active and captures the focus with each update, causing major inconvenience in running other software on the same workstation.