### PR TITLE
Limit number of lines displayed simultaneously on 1D plot showing final data (fly1d)

### DIFF
--- a/hxnfly/callbacks/liveplot.py
+++ b/hxnfly/callbacks/liveplot.py
@@ -129,6 +129,11 @@ class FlyLivePlot(LivePlotBase):
         self.ylabel = y
         self.enabled = True
 
+        # Limit the number of lines simultaneously shown on the final plot
+        #   (to avoid 100s of lines to be accumulated).
+        self.final_plot_max_lines = 6
+
+
     def _reset(self):
         super()._reset()
 
@@ -188,6 +193,13 @@ class FlyLivePlot(LivePlotBase):
         super().scan_finished(doc, scan_data, cancelled=cancelled, **kwargs)
 
         ax, fig = self.final_ax, self.final_fig
+
+        # Delete the extra lines from the plot. Leave 'self.final_plot_max_lines - 1' lines
+        while True:
+            l = ax.get_lines()
+            if len(l) < self.final_plot_max_lines:
+                break
+            l[0].remove()
 
         if scan_data is None:
             logger.error('No scan data for the live plot')

--- a/hxnfly/callbacks/liveplot.py
+++ b/hxnfly/callbacks/liveplot.py
@@ -196,10 +196,10 @@ class FlyLivePlot(LivePlotBase):
 
         # Delete the extra lines from the plot. Leave 'self.final_plot_max_lines - 1' lines
         while True:
-            l = ax.get_lines()
-            if len(l) < self.final_plot_max_lines:
+            lns = ax.get_lines()
+            if len(lns) < self.final_plot_max_lines:
                 break
-            l[0].remove()
+            lns[0].remove()
 
         if scan_data is None:
             logger.error('No scan data for the live plot')


### PR DESCRIPTION
It was observed, that while running a large batch of scans (e.g. `mll_tomo_scan`), 1D plot showing final data accumulate hundreds of lines (millions of data points), which takes a long time to redraw. To avoid inserting long pauses (a few seconds) between scans, it is proposed to restrict number of lines to 6 and remove old lines as the new lines are added. The number 6 is arbitrary and could be changed or made a parameter later.